### PR TITLE
Add typed config function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zero-dependency library for using .env files with types and default values
 - Variable types
 - Default values
 
-In both sitautions, logic specific to the configuration (type casting, default checking) ends up seeping into the application logic. If any of these values are re-used in different parts of the app this can even lead to duplication.
+In both situations, logic specific to the configuration (type casting, default checking) ends up seeping into the application logic. If any of these values are re-used in different parts of the app this can even lead to duplication.
 
 Instead, `env-smart` enables declaring default values and types for all environmental variables in additional configuration files. It loads the contents of the `.env` file if present, but defaults and type checking are applied to the process' env if not.
 
@@ -37,12 +37,40 @@ require('env-smart').load();
 console.log(process.env.PORT);
 ```
 
-Using a `.env` files to store environmental variables makes managing different configurations between deployments much easier. Example file:
+Using a `.env` file to store environmental variables makes managing different configurations between deployments much easier. Example file:
 
 ```ini
 PORT=8080
 VERBOSE=TRUE
 API_KEY=xyz
+```
+
+### Strictly Typed Configuration
+
+IF you're using TypeScript, the `config` function makes parsing strictly typed configurations simple:
+
+```typescript
+import envSmart from 'env-smart';
+
+// Define config type
+export type Configuration = {
+  host: string;
+  port: number;
+  verbose: boolean;
+};
+
+// Transform the dictionary into a configuration type
+export const config = envSmart.config<Configuration>((env) => {
+  // `env` is now populated from the .env file, process env, and defaults
+  return {
+    host: env.HOST,
+    port: env.PORT,
+    verbose: env.VERBOSE,
+  };
+});
+
+// `config` is now strictly typed
+console.log(`Host: ${config.host} port: ${config.port} verbose: ${config.verbose} `);
 ```
 
 ### Types and Defaults

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ API_KEY=xyz
 
 ### Strictly Typed Configuration
 
-IF you're using TypeScript, the `config` function makes parsing strictly typed configurations simple:
+If you're using TypeScript, the `config` function makes parsing strictly typed configurations simple:
 
 ```typescript
 import envSmart from 'env-smart';

--- a/examples/typed/.env
+++ b/examples/typed/.env
@@ -1,0 +1,3 @@
+HOST=api-v2.example.com
+PORT=8081
+VERBOSE=true

--- a/examples/typed/.env.defaults
+++ b/examples/typed/.env.defaults
@@ -1,0 +1,3 @@
+HOST=api.example.com
+PORT=number=8080
+VERBOSE=boolean=false

--- a/examples/typed/typed.ts
+++ b/examples/typed/typed.ts
@@ -16,7 +16,7 @@ export const config = env.config<Configuration>((env) => {
   };
 });
 
-// `config` is now a fully typed config file fully populated via
+// `config` is now a fully typed config file fully populated via the `.env` file and the process env
 
 console.log(
   `Host: ${config.host} port: ${config.port} verbose: ${config.verbose} `,

--- a/examples/typed/typed.ts
+++ b/examples/typed/typed.ts
@@ -1,0 +1,24 @@
+// import env from 'env-smart';
+import env from '../../';
+
+export type Configuration = {
+  host: string;
+  port: number;
+  verbose: boolean;
+};
+
+export const config = env.config<Configuration>((env) => {
+  // `env` is now populated from the .env file, process config, and defaults
+  return {
+    host: env.HOST,
+    port: env.PORT,
+    verbose: env.VERBOSE,
+  };
+});
+
+// `config` is now a fully typed config file fully populated via
+
+console.log(
+  `Host: ${config.host} port: ${config.port} verbose: ${config.verbose} `,
+);
+console.dir(config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,16 @@
+import { load, loadOptions } from './load';
+
+/**
+ * Return structured, typed configuration information from both the process ENV and a .env file
+ * Takes in a transform function that populates a configuration type
+ */
+export function config<T>(
+  transform: (env: { [key: string]: any }) => T,
+  options?: loadOptions,
+): T {
+  // Load the contents of the `.env` file and the process env
+  const env = load(options);
+
+  // Transform the env into the config type
+  return <T>transform(env);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { load, loadOptions } from './load';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import load from './load';
+import { config } from './config';
+import { load } from './load';
 import { parse, parseFile } from './parse';
-import type from './type';
+import { type } from './type';
 
-export { load, type, parse, parseFile };
-export default { load, type, parse, parseFile };
+export { load, type, parse, parseFile, config };
+export default { load, type, parse, parseFile, config };

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,12 +1,10 @@
 import { parseFile } from './parse';
-import type from './type';
+import { type } from './type';
 
 /**
- * Load env values
- * @param   {object} [parameters] - Loading options
- * @returns {object} - Object containing env values found in a .env file (or the process )
+ * Options for loading env values
  */
-export default function load(options?: {
+export type loadOptions = {
   lowercase?: boolean;
   uppercase?: boolean;
   verbose?: boolean;
@@ -18,7 +16,14 @@ export default function load(options?: {
   envFilename?: string;
   envDefaultsFilename?: string;
   envTypesFilename?: string;
-}): {
+};
+
+/**
+ * Load env values
+ * @param   {object} [options] - Loading options
+ * @returns {object} - Object containing env values found in a .env file (or the process )
+ */
+export function load(options?: loadOptions): {
   [key: string]: unknown;
 } {
   if (typeof options !== 'object') {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,4 @@
-import type from './type';
+import { type } from './type';
 import fs from 'fs';
 
 /**

--- a/src/type.ts
+++ b/src/type.ts
@@ -5,7 +5,7 @@
  * @param   {object}                             [options] Additional options. Optional.
  * @returns {string|boolean|number|object|Array} The value casted into the specified type.
  */
-export default function type(
+export function type(
   value: string,
   type: string,
   options?: { verbose?: boolean }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,33 @@
+jest.mock('../src/load');
+import { mocked } from 'jest-mock';
+import { config } from '../src/index';
+import { load } from '../src/load'
+
+const loadMocked = mocked(load, true)
+
+describe('config() function', () => {
+
+  test(`properly returns typed env`, () => {
+    loadMocked.mockReturnValue({
+      PORT: 8080,
+      HOST: 'api.example.com',
+      VERBOSE: true
+    });
+
+    const typed = config<{
+      host: string;
+      port: number;
+      verbose: boolean
+    }>((env) => {
+      return {
+        host: env.HOST,
+        port: env.PORT,
+        verbose: env.VERBOSE
+      };
+    });
+
+    expect(typed.host).toBe('api.example.com');
+    expect(typed.port).toBe(8080);
+    expect(typed.verbose).toBe(true);
+  });
+});


### PR DESCRIPTION
In TypeScript, using `Record<string,unknown>` doesn't really cut it anymore.

```typescript
import envSmart from 'env-smart';

// Define config type
export type Configuration = {
  host: string;
  port: number;
  verbose: boolean;
};

// Transform the dictionary into a configuration type
export const config = envSmart.config<Configuration>((env) => {
  // `env` is now populated from the .env file, process env, and defaults
  return {
    host: env.HOST,
    port: env.PORT,
    verbose: env.VERBOSE,
  };
});

// `config` is now strictly typed
console.log(`Host: ${config.host} port: ${config.port} verbose: ${config.verbose} `);
```